### PR TITLE
[Feature]: Allow just in time table name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivan-lee/typed-ddb",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A package to hold all helper libraries related for data modeling and transformation",
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json --force",
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.1",
+    "class-validator": "^0.14.3",
     "dynamoose": "^4.0.4",
     "@preact/signals": "^1.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       class-validator:
-        specifier: ^0.14.1
-        version: 0.14.2
+        specifier: ^0.14.3
+        version: 0.14.3
       dynamoose:
         specifier: ^4.0.4
         version: 4.0.4
@@ -811,8 +811,8 @@ packages:
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
-  '@types/validator@13.15.2':
-    resolution: {integrity: sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==}
+  '@types/validator@13.15.10':
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -1099,8 +1099,8 @@ packages:
   class-transformer@0.5.1:
     resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
 
-  class-validator@0.14.2:
-    resolution: {integrity: sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==}
+  class-validator@0.14.3:
+    resolution: {integrity: sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2301,8 +2301,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  validator@13.15.15:
-    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+  validator@13.15.23:
+    resolution: {integrity: sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==}
     engines: {node: '>= 0.10'}
 
   walker@1.0.8:
@@ -3608,7 +3608,7 @@ snapshots:
 
   '@types/uuid@9.0.8': {}
 
-  '@types/validator@13.15.2': {}
+  '@types/validator@13.15.10': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -3949,11 +3949,11 @@ snapshots:
 
   class-transformer@0.5.1: {}
 
-  class-validator@0.14.2:
+  class-validator@0.14.3:
     dependencies:
-      '@types/validator': 13.15.2
+      '@types/validator': 13.15.10
       libphonenumber-js: 1.12.10
-      validator: 13.15.15
+      validator: 13.15.23
 
   cliui@8.0.1:
     dependencies:
@@ -5327,7 +5327,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  validator@13.15.15: {}
+  validator@13.15.23: {}
 
   walker@1.0.8:
     dependencies:

--- a/src/dynamodb/__test__/entities/User.ts
+++ b/src/dynamodb/__test__/entities/User.ts
@@ -2,7 +2,7 @@ import { Table, Attribute, PartitionKey, Index, HasOne, HasMany } from '../../co
 import { Profile } from './Profile';
 import { Post } from './Post';
 
-@Table('Users')
+@Table(() => 'Users')
 export class User {
   @PartitionKey()
   @Attribute({ type: 'string' })

--- a/src/dynamodb/core/Repository.ts
+++ b/src/dynamodb/core/Repository.ts
@@ -37,7 +37,8 @@ export class Repository<T, PaginationKey extends string = string> {
     // Generate DynamoDB schema dynamically
     const schemaFields: any = {};
 
-    const tableName = Reflect.getMetadata('tableName', ModelClass) || ModelClass.name;
+    const tableNameProvider = Reflect.getMetadata('tableName', ModelClass) || ModelClass.name;
+    const tableName = typeof tableNameProvider === 'function' ? tableNameProvider() : tableNameProvider;
 
     // Retrieve all decorated keys
     const keys: string[] = Reflect.getMetadata('keys', ModelClass.prototype) || [];

--- a/src/dynamodb/core/decorators.ts
+++ b/src/dynamodb/core/decorators.ts
@@ -43,7 +43,7 @@ interface SecondaryIndexOptions {
   sortKey?: string;
 }
 
-export function Table(name: string) {
+export function Table(name: string | (() => string)) {
   return (constructor: Function) => {
     Reflect.defineMetadata('tableName', name, constructor);
   };


### PR DESCRIPTION
# Background
More flexible table name for use case like AWS Amplify or any other ephemeral environment deployment where the table name only be crafted during application deployment.

## How to use
```ts
import { Table } from '...';

@Table(() => process.env.MYTABLE_TABLE_NAME)
export class MyTable() {
  ...
}
```