### PR TITLE
[Feature]: `AmplifyAdapter`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivan-lee/typed-ddb",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A package to hold all helper libraries related for data modeling and transformation",
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json --force",
@@ -10,15 +10,28 @@
   },
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
-  "keywords": ["dynamodb", "nosql", "typeorm", "typescript", "orm", "aws"],
+  "bin": {
+    "typed-ddb": "./dist/cli/index.js"
+  },
+  "keywords": [
+    "dynamodb",
+    "nosql",
+    "typeorm",
+    "typescript",
+    "orm",
+    "aws",
+    "amplify-gen-2"
+  ],
   "repository": "https://github.com/ivan-zynesis/typed-ddb",
   "author": "ivan-zynesis",
   "license": "MIT",
   "dependencies": {
+    "@preact/signals": "^1.2.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
     "dynamoose": "^4.0.4",
-    "@preact/signals": "^1.2.2"
+    "reflect-metadata": "^0.2.2",
+    "tsx": "^4.21.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
@@ -29,7 +42,6 @@
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-node": "^11.1.0",
     "jest": "^29.7.0",
-    "reflect-metadata": "^0.2.2",
     "testcontainers": "^11.2.1",
     "ts-jest": "^29.2.5",
     "typescript": "^5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       ts-jest:
         specifier: ^29.2.5
         version: 29.4.0(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.0.14))(typescript@5.8.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -354,6 +357,162 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@esbuild/aix-ppc64@0.27.1':
+    resolution: {integrity: sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.1':
+    resolution: {integrity: sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.1':
+    resolution: {integrity: sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.1':
+    resolution: {integrity: sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.1':
+    resolution: {integrity: sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.1':
+    resolution: {integrity: sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.1':
+    resolution: {integrity: sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.1':
+    resolution: {integrity: sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.1':
+    resolution: {integrity: sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.1':
+    resolution: {integrity: sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.1':
+    resolution: {integrity: sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.1':
+    resolution: {integrity: sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.1':
+    resolution: {integrity: sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.1':
+    resolution: {integrity: sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.1':
+    resolution: {integrity: sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.1':
+    resolution: {integrity: sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.1':
+    resolution: {integrity: sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.1':
+    resolution: {integrity: sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.1':
+    resolution: {integrity: sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.1':
+    resolution: {integrity: sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.1':
+    resolution: {integrity: sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.1':
+    resolution: {integrity: sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.1':
+    resolution: {integrity: sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.1':
+    resolution: {integrity: sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.1':
+    resolution: {integrity: sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.1':
+    resolution: {integrity: sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -1232,6 +1391,11 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
+  esbuild@0.27.1:
+    resolution: {integrity: sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1433,6 +1597,9 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2033,6 +2200,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
@@ -2242,6 +2412,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
@@ -2931,6 +3106,84 @@ snapshots:
   '@balena/dockerignore@1.0.2': {}
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@esbuild/aix-ppc64@0.27.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/android-arm@0.27.1':
+    optional: true
+
+  '@esbuild/android-x64@0.27.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.1':
+    optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.31.0)':
     dependencies:
@@ -4093,6 +4346,35 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  esbuild@0.27.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.1
+      '@esbuild/android-arm': 0.27.1
+      '@esbuild/android-arm64': 0.27.1
+      '@esbuild/android-x64': 0.27.1
+      '@esbuild/darwin-arm64': 0.27.1
+      '@esbuild/darwin-x64': 0.27.1
+      '@esbuild/freebsd-arm64': 0.27.1
+      '@esbuild/freebsd-x64': 0.27.1
+      '@esbuild/linux-arm': 0.27.1
+      '@esbuild/linux-arm64': 0.27.1
+      '@esbuild/linux-ia32': 0.27.1
+      '@esbuild/linux-loong64': 0.27.1
+      '@esbuild/linux-mips64el': 0.27.1
+      '@esbuild/linux-ppc64': 0.27.1
+      '@esbuild/linux-riscv64': 0.27.1
+      '@esbuild/linux-s390x': 0.27.1
+      '@esbuild/linux-x64': 0.27.1
+      '@esbuild/netbsd-arm64': 0.27.1
+      '@esbuild/netbsd-x64': 0.27.1
+      '@esbuild/openbsd-arm64': 0.27.1
+      '@esbuild/openbsd-x64': 0.27.1
+      '@esbuild/openharmony-arm64': 0.27.1
+      '@esbuild/sunos-x64': 0.27.1
+      '@esbuild/win32-arm64': 0.27.1
+      '@esbuild/win32-ia32': 0.27.1
+      '@esbuild/win32-x64': 0.27.1
+
   escalade@3.2.0: {}
 
   escape-string-regexp@2.0.0: {}
@@ -4307,6 +4589,10 @@ snapshots:
   get-port@7.1.0: {}
 
   get-stream@6.0.1: {}
+
+  get-tsconfig@4.13.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -5063,6 +5349,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve.exports@2.0.3: {}
 
   resolve@1.22.10:
@@ -5284,6 +5572,13 @@ snapshots:
       jest-util: 29.7.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.1
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tweetnacl@0.14.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       dynamoose:
         specifier: ^4.0.4
         version: 4.0.4
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -45,18 +51,12 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@24.0.14)
-      reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
       testcontainers:
         specifier: ^11.2.1
         version: 11.2.1
       ts-jest:
         specifier: ^29.2.5
         version: 29.4.0(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.0.14))(typescript@5.8.3)
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       typescript:
         specifier: ^5.8.3
         version: 5.8.3

--- a/src/adapters/__test__/AmplifyAdapter.spec.ts
+++ b/src/adapters/__test__/AmplifyAdapter.spec.ts
@@ -1,0 +1,316 @@
+import { AmplifyAdapter } from '../amplify/AmplifyAdapter';
+import { AmplifyTypeMapper } from '../amplify/AmplifyTypeMapper';
+import { AmplifyIndexGenerator } from '../amplify/AmplifyIndexGenerator';
+import { User } from './entities/User';
+import { Post } from './entities/Post';
+import { Profile } from './entities/Profile';
+
+describe('AmplifyTypeMapper', () => {
+  let mapper: AmplifyTypeMapper;
+
+  beforeEach(() => {
+    mapper = new AmplifyTypeMapper();
+  });
+
+  describe('Basic Type Mapping', () => {
+    it('should map string type', () => {
+      const result = mapper.mapAttributeType('string', false, false, false);
+      expect(result).toBe('a.string().required()');
+    });
+
+    it('should map number type', () => {
+      const result = mapper.mapAttributeType('number', false, false, false);
+      expect(result).toBe('a.float().required()');
+    });
+
+    it('should map boolean type', () => {
+      const result = mapper.mapAttributeType('boolean', false, false, false);
+      expect(result).toBe('a.boolean().required()');
+    });
+
+    it('should map date type', () => {
+      const result = mapper.mapAttributeType('date', false, false, false);
+      expect(result).toBe('a.datetime().required()');
+    });
+
+    it('should map object type', () => {
+      const result = mapper.mapAttributeType('object', false, false, false);
+      expect(result).toBe('a.json().required()');
+    });
+
+    it('should map array type', () => {
+      const result = mapper.mapAttributeType('array', false, false, false);
+      expect(result).toBe('a.json().required()');
+    });
+  });
+
+  describe('Enum Type Mapping', () => {
+    it('should map enum type with values', () => {
+      const result = mapper.mapAttributeType('enums', false, false, false, ['draft', 'published', 'archived']);
+      expect(result).toBe("a.enum(['draft', 'published', 'archived']).required()");
+    });
+
+    it('should throw error for enum without values', () => {
+      expect(() => {
+        mapper.mapAttributeType('enums', false, false, false);
+      }).toThrow('Enum type requires enum values');
+    });
+  });
+
+  describe('Optional Modifier', () => {
+    it('should not add required() for optional fields', () => {
+      const result = mapper.mapAttributeType('string', true, false, false);
+      expect(result).toBe('a.string()');
+    });
+
+    it('should add required() for non-optional fields', () => {
+      const result = mapper.mapAttributeType('string', false, false, false);
+      expect(result).toBe('a.string().required()');
+    });
+  });
+
+  describe('Key Type Mapping', () => {
+    it('should map partition key to a.id().required()', () => {
+      const result = mapper.mapAttributeType('string', false, true, false);
+      expect(result).toBe('a.id().required()');
+    });
+
+    it('should map sort key to a.id().required()', () => {
+      const result = mapper.mapAttributeType('string', false, false, true);
+      expect(result).toBe('a.id().required()');
+    });
+  });
+});
+
+describe('AmplifyIndexGenerator', () => {
+  let generator: AmplifyIndexGenerator;
+
+  beforeEach(() => {
+    generator = new AmplifyIndexGenerator('User');
+  });
+
+  describe('Index Generation', () => {
+    it('should generate index without sort key', () => {
+      const indexes = [{
+        fieldName: 'email',
+        indexName: 'emailGlobalIndex',
+        type: 'global' as const,
+        queryField: 'usersByEmail'
+      }];
+      const result = generator.generateIndexes(indexes);
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain("('emailGlobalIndex')");
+      expect(result[0]).toContain(".name('emailGlobalIndex')");
+      expect(result[0]).toContain(".queryField('usersByEmail')");
+    });
+
+    it('should generate index with sort key', () => {
+      const indexes = [{
+        fieldName: 'status',
+        indexName: 'StatusIndex',
+        sortKeyField: 'publishedAt',
+        type: 'global' as const,
+        queryField: 'postsByStatus'
+      }];
+      const result = generator.generateIndexes(indexes);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain("('StatusIndex')");
+      expect(result[0]).toContain(".sortKeys(['publishedAt'])");
+      expect(result[0]).toContain(".queryField('postsByStatus')");
+    });
+
+    it('should return empty array for no indexes', () => {
+      const result = generator.generateIndexes([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle multiple indexes', () => {
+      const indexes = [
+        {
+          fieldName: 'email',
+          indexName: 'emailIndex',
+          type: 'global' as const,
+          queryField: 'usersByEmail'
+        },
+        {
+          fieldName: 'status',
+          indexName: 'statusIndex',
+          sortKeyField: 'createdAt',
+          type: 'global' as const,
+          queryField: 'usersByStatus'
+        }
+      ];
+      const result = generator.generateIndexes(indexes);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain("('emailIndex')");
+      expect(result[1]).toContain("('statusIndex')");
+    });
+  });
+
+  describe('QueryField Name Generation', () => {
+    it('should use provided queryField', () => {
+      const indexes = [{
+        fieldName: 'emailAddress',
+        indexName: 'emailAddressIndex',
+        type: 'global' as const,
+        queryField: 'usersByEmailAddress'
+      }];
+      const result = generator.generateIndexes(indexes);
+      expect(result[0]).toContain('usersByEmailAddress');
+    });
+
+    it('should generate queryField if not provided', () => {
+      const indexes = [{
+        fieldName: 'emailAddress',
+        indexName: 'emailAddressIndex',
+        type: 'global' as const
+      }];
+      const result = generator.generateIndexes(indexes);
+      expect(result[0]).toContain('UserByEmailAddress');
+    });
+  });
+});
+
+describe('AmplifyAdapter Integration Tests', () => {
+  describe('User Entity', () => {
+    let adapter: AmplifyAdapter<User>;
+
+    beforeEach(() => {
+      adapter = new AmplifyAdapter(User);
+    });
+
+    it('should generate modelFields and secondaryIndexes', () => {
+      const fields = adapter.modelFields();
+      const indexes = adapter.secondaryIndexes();
+
+      expect(fields).toContain('id: a.id().required()');
+      expect(fields).toContain('email: a.string().required()');
+      expect(fields).toContain('name: a.string().required()');
+      expect(fields).toContain('age: a.float().required()');
+      expect(fields).toContain('isActive: a.boolean().required()');
+      expect(fields).toContain('metadata: a.json()');
+      expect(fields).toContain('tags: a.json()');
+      expect(fields).toContain('CreatedAt: a.datetime().required()');
+      expect(fields).toContain('UpdatedAt: a.datetime()');
+
+      expect(indexes).toBeInstanceOf(Array);
+      expect(indexes.length).toBeGreaterThan(0);
+      expect(indexes[0]).toContain('usersByEmail');
+    });
+
+    it('should generate modelFields correctly', () => {
+      const fields = adapter.modelFields();
+
+      expect(fields).toContain('id: a.id().required()');
+      expect(fields).toContain('email: a.string().required()');
+      expect(fields).toContain('name: a.string().required()');
+      expect(fields).toContain('age: a.float().required()');
+      expect(fields).toContain('isActive: a.boolean().required()');
+      expect(fields).toContain('metadata: a.json()');
+      expect(fields).toContain('tags: a.json()');
+      expect(fields).toContain('CreatedAt: a.datetime().required()');
+      expect(fields).toContain('UpdatedAt: a.datetime()');
+    });
+
+    it('should generate secondary indexes', () => {
+      const indexes = adapter.secondaryIndexes();
+
+      expect(indexes).toBeInstanceOf(Array);
+      expect(indexes.length).toBeGreaterThan(0);
+      expect(indexes[0]).toContain('usersByEmail');
+    });
+  });
+
+  describe('Post Entity', () => {
+    let adapter: AmplifyAdapter<Post>;
+
+    beforeEach(() => {
+      adapter = new AmplifyAdapter(Post);
+    });
+
+    it('should generate modelFields correctly', () => {
+      const fields = adapter.modelFields();
+
+      expect(fields).toContain('id: a.id().required()');
+      expect(fields).toContain('title: a.string().required()');
+      expect(fields).toContain('content: a.string().required()');
+      expect(fields).toContain('status: a.enum');
+      expect(fields).toContain('publishedAt: a.float().required()');
+      expect(fields).toContain('CreatedAt: a.datetime().required()');
+      expect(fields).toContain('UpdatedAt: a.datetime()');
+    });
+
+    it('should handle enum fields', () => {
+      const fields = adapter.modelFields();
+
+      expect(fields).toContain("status: a.enum(['draft', 'published', 'archived']).required()");
+    });
+
+    it('should handle @BelongsTo relationships', () => {
+      const fields = adapter.modelFields();
+
+      expect(fields).toContain('userId:');
+      expect(fields).toContain("a.belongsTo('User', 'userId')");
+    });
+
+    it('should generate index with sort key', () => {
+      const indexes = adapter.secondaryIndexes();
+
+      expect(indexes).toBeInstanceOf(Array);
+      expect(indexes.length).toBeGreaterThan(0);
+      expect(indexes[0]).toContain('StatusIndex');
+      expect(indexes[0]).toContain("sortKeys(['publishedAt'])");
+      expect(indexes[0]).toContain('postsByStatus');
+    });
+  });
+
+  describe('Profile Entity', () => {
+    let adapter: AmplifyAdapter<Profile>;
+
+    beforeEach(() => {
+      adapter = new AmplifyAdapter(Profile);
+    });
+
+    it('should generate modelFields for Profile', () => {
+      const fields = adapter.modelFields();
+
+      expect(fields).toContain('userId: a.id().required()');
+    });
+
+    it('should handle @BelongsTo as partition key', () => {
+      const fields = adapter.modelFields();
+
+      expect(fields).toContain('userId: a.id().required()');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle table name as function', () => {
+      const adapter = new AmplifyAdapter(User);
+      const fields = adapter.modelFields();
+
+      // Should generate successfully regardless of table name type
+      expect(fields).toContain('id: a.id().required()');
+    });
+
+    it('should handle entities without indexes', () => {
+      const adapter = new AmplifyAdapter(Profile);
+      const indexes = adapter.secondaryIndexes();
+
+      // Profile doesn't have indexes, should return empty array
+      expect(indexes).toEqual([]);
+    });
+
+    it('should handle optional fields correctly', () => {
+      const adapter = new AmplifyAdapter(User);
+      const fields = adapter.modelFields();
+
+      // metadata and tags are optional
+      expect(fields).toContain('metadata: a.json()');
+      expect(fields).toContain('tags: a.json()');
+      expect(fields).not.toContain('metadata: a.json().required()');
+      expect(fields).not.toContain('tags: a.json().required()');
+    });
+  });
+});

--- a/src/adapters/__test__/AmplifyGsi-Repository.spec.ts
+++ b/src/adapters/__test__/AmplifyGsi-Repository.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Test to ensure Repository works 100% with @AmplifyGsi decorated entities
+ */
+import { Repository } from '../../dynamodb/core/Repository';
+import { User } from './entities/User';
+import { Post } from './entities/Post';
+
+describe('Repository with @AmplifyGsi decorated entities', () => {
+  describe('User entity with @AmplifyGsi', () => {
+    let repo: Repository<User>;
+
+    beforeEach(() => {
+      repo = new Repository(User);
+    });
+
+    it('should create repository successfully', () => {
+      expect(repo).toBeDefined();
+      expect(repo.ModelClass).toBe(User);
+    });
+
+    it('should get default index name correctly', () => {
+      // @AmplifyGsi creates global indexes
+      const indexName = repo.getDefaultIndexName('global', 'email');
+      expect(indexName).toBe('emailGlobalIndex');
+    });
+  });
+
+  describe('Post entity with @AmplifyGsi composite index', () => {
+    let repo: Repository<Post>;
+
+    beforeEach(() => {
+      repo = new Repository(Post);
+    });
+
+    it('should create repository successfully', () => {
+      expect(repo).toBeDefined();
+      expect(repo.ModelClass).toBe(Post);
+    });
+
+    it('should generate default composite index name', () => {
+      // When using getDefaultIndexName, it generates from field names
+      const indexName = repo.getDefaultIndexName('global', 'status', 'publishedAt');
+      expect(indexName).toBe('status-publishedAtGlobalIndex');
+    });
+  });
+
+  describe('Index metadata compatibility', () => {
+    it('should have proper index metadata for Repository', () => {
+      const prototype = User.prototype;
+
+      // Check that standard @Index metadata exists (created by @AmplifyGsi)
+      const indexMeta = Reflect.getMetadata('index', prototype, 'email');
+      expect(indexMeta).toBeDefined();
+      expect(indexMeta.type).toBe('global');
+
+      // Check that amplifyGsi metadata also exists
+      const amplifyMeta = Reflect.getMetadata('amplifyGsi', prototype, 'email');
+      expect(amplifyMeta).toBeDefined();
+      expect(amplifyMeta.queryField).toBe('usersByEmail');
+    });
+
+    it('should have proper composite index metadata', () => {
+      const prototype = Post.prototype;
+
+      const indexMeta = Reflect.getMetadata('index', prototype, 'status');
+      expect(indexMeta).toBeDefined();
+      expect(indexMeta.type).toBe('global');
+      expect(indexMeta.sortKey).toBe('publishedAt');
+
+      const amplifyMeta = Reflect.getMetadata('amplifyGsi', prototype, 'status');
+      expect(amplifyMeta).toBeDefined();
+      expect(amplifyMeta.queryField).toBe('postsByStatus');
+      expect(amplifyMeta.sortKey).toBe('publishedAt');
+    });
+  });
+});

--- a/src/adapters/__test__/entities/Comment.ts
+++ b/src/adapters/__test__/entities/Comment.ts
@@ -1,0 +1,37 @@
+import { Table, Attribute, SortKey, BelongsTo } from '../../../dynamodb/core/decorators';
+import { Post } from './Post';
+import { User } from './User';
+
+@Table('Comments')
+export class Comment {
+  @BelongsTo<Pick<Post, 'userId' | 'id'>>(
+    (post: Pick<Post, 'userId' | 'id'>) => `${post.userId.id}#${post.id}`,
+    (postId: string) => {
+      const [userId, id] = postId.split('#');
+      return { userId: { id: userId }, id };
+    }
+  )
+  @Attribute({ type: 'string' })
+  postId: Pick<Post, 'userId' | 'id'>;
+
+  @SortKey()
+  @Attribute({ type: 'string' })
+  id: string;
+
+  @BelongsTo<Pick<User, 'id'>>(
+    (user: Pick<User, 'id'>) => user.id,
+    (userId: string) => ({ id: userId }),
+    'index'
+  )
+  @Attribute({ type: 'string' })
+  authorId: Pick<User, 'id'>;
+
+  @Attribute({ type: 'string' })
+  content: string;
+
+  @Attribute({ type: 'date' })
+  CreatedAt: Date;
+
+  @Attribute({ type: 'date', optional: true })
+  UpdatedAt?: Date;
+}

--- a/src/adapters/__test__/entities/Post.ts
+++ b/src/adapters/__test__/entities/Post.ts
@@ -1,0 +1,44 @@
+import { Table, Attribute, SortKey, BelongsTo, HasMany } from '../../../dynamodb/core/decorators';
+import { AmplifyGsi } from '../../amplify/decorators';
+import { User } from './User';
+import { Comment } from './Comment';
+
+@Table('Posts')
+export class Post {
+  @BelongsTo<Pick<User, 'id'>>(
+    (user: Pick<User, 'id'>) => user.id,
+    (userId: string) => ({ id: userId })
+  )
+  @Attribute({ type: 'string' })
+  userId: Pick<User, 'id'>;
+
+  @SortKey()
+  @Attribute({ type: 'string' })
+  id: string;
+
+  @Attribute({ type: 'string' })
+  title: string;
+
+  @Attribute({ type: 'string' })
+  content: string;
+
+  @AmplifyGsi({
+    name: 'StatusIndex',
+    sortKey: 'publishedAt',
+    queryField: 'postsByStatus'
+  })
+  @Attribute({ type: 'enums', enums: ['draft', 'published', 'archived'] })
+  status: 'draft' | 'published' | 'archived';
+
+  @Attribute({ type: 'number' })
+  publishedAt: number;
+
+  @Attribute({ type: 'date' })
+  CreatedAt: Date;
+
+  @Attribute({ type: 'date', optional: true })
+  UpdatedAt?: Date;
+
+  @HasMany(() => Comment)
+  comments?: Comment[];
+}

--- a/src/adapters/__test__/entities/Profile.ts
+++ b/src/adapters/__test__/entities/Profile.ts
@@ -1,0 +1,29 @@
+import { Table, Attribute, PartitionKey, BelongsTo } from '../../../dynamodb/core/decorators';
+import { User } from './User';
+
+@Table('Profiles')
+export class Profile {
+  @PartitionKey()
+  @BelongsTo<Pick<User, 'id'>>(
+    (user: Pick<User, 'id'>) => user.id,
+    (userId: string) => ({ id: userId })
+  )
+  @Attribute({ type: 'string' })
+  userId: Pick<User, 'id'>;
+
+  @Attribute({ type: 'string', optional: true })
+  bio?: string;
+
+  @Attribute({ type: 'object', optional: true })
+  settings?: {
+    theme: 'light' | 'dark';
+    notifications: boolean;
+    privacy: 'public' | 'private';
+  };
+
+  @Attribute({ type: 'date' })
+  CreatedAt: Date;
+
+  @Attribute({ type: 'date', optional: true })
+  UpdatedAt?: Date;
+}

--- a/src/adapters/__test__/entities/User.ts
+++ b/src/adapters/__test__/entities/User.ts
@@ -1,0 +1,42 @@
+import { Table, Attribute, PartitionKey, HasOne, HasMany } from '../../../dynamodb/core/decorators';
+import { AmplifyGsi } from '../../amplify/decorators';
+import { Profile } from './Profile';
+import { Post } from './Post';
+
+@Table(() => 'Users')
+export class User {
+  @PartitionKey()
+  @Attribute({ type: 'string' })
+  id: string;
+
+  @AmplifyGsi({ queryField: 'usersByEmail' })
+  @Attribute({ type: 'string' })
+  email: string;
+
+  @Attribute({ type: 'string' })
+  name: string;
+
+  @Attribute({ type: 'number' })
+  age: number;
+
+  @Attribute({ type: 'boolean' })
+  isActive: boolean;
+
+  @Attribute({ type: 'object', optional: true })
+  metadata?: Record<string, any>;
+
+  @Attribute({ type: 'array', optional: true })
+  tags?: string[];
+
+  @Attribute({ type: 'date' })
+  CreatedAt: Date;
+
+  @Attribute({ type: 'date', optional: true })
+  UpdatedAt?: Date;
+
+  @HasOne(() => Profile)
+  profile?: Profile;
+
+  @HasMany(() => Post)
+  posts?: Post[];
+}

--- a/src/adapters/amplify/AmplifyAdapter.ts
+++ b/src/adapters/amplify/AmplifyAdapter.ts
@@ -1,0 +1,224 @@
+import 'reflect-metadata';
+import { AmplifyTypeMapper } from './AmplifyTypeMapper';
+import { AmplifyIndexGenerator } from './AmplifyIndexGenerator';
+import { AmplifyRelationshipMapper } from './AmplifyRelationshipMapper';
+import { EntityMetadata, FieldMetadata, IndexMetadata } from './types';
+
+export class AmplifyAdapter<T> {
+  private readonly ModelClass: new () => T;
+  private readonly className: string;
+  private readonly typeMapper: AmplifyTypeMapper;
+  private readonly indexGenerator: AmplifyIndexGenerator;
+  private readonly relationshipMapper: AmplifyRelationshipMapper;
+
+  constructor(ModelClass: new () => T) {
+    this.ModelClass = ModelClass;
+    this.className = ModelClass.name;
+    this.typeMapper = new AmplifyTypeMapper();
+    this.indexGenerator = new AmplifyIndexGenerator(this.className);
+    this.relationshipMapper = new AmplifyRelationshipMapper();
+  }
+
+  modelFields(): string {
+    const metadata = this.extractMetadata();
+    const fieldDefs: string[] = [];
+
+    for (const field of metadata.fields) {
+      // Skip virtual relationship fields (@HasOne/@HasMany without actual column)
+      if ((field.relationship?.type === 'hasOne' || field.relationship?.type === 'hasMany')
+          && field.type === 'relationship') {
+        // This is a virtual relationship field, generate only relationship def
+        if (field.relationship.relatedModelClass) {
+          const relDef = field.relationship.type === 'hasOne'
+            ? this.relationshipMapper.generateHasOne(field.relationship.relatedModelClass, this.ModelClass)
+            : this.relationshipMapper.generateHasMany(field.relationship.relatedModelClass, this.ModelClass);
+          fieldDefs.push(`${field.name}: ${relDef}`);
+        }
+        continue;
+      }
+
+      if (field.relationship?.type === 'belongsTo' && field.relationship.relatedModelClass) {
+        // For @BelongsTo: generate the field definition
+        const typeDef = this.typeMapper.mapAttributeType(
+          field.type,
+          field.optional,
+          field.isPartitionKey,
+          field.isSortKey
+        );
+        fieldDefs.push(`${field.name}: ${typeDef}`);
+
+        // Add relationship field - infer name by removing 'Id' suffix
+        const relationshipFieldName = field.name.replace(/Id$/i, '').toLowerCase() === field.name.toLowerCase()
+          ? field.name + 'Relation'  // If no 'Id' suffix, append 'Relation'
+          : field.name.replace(/Id$/i, '');  // Remove 'Id' suffix
+
+        const relDef = this.relationshipMapper.generateBelongsTo(
+          field.relationship.relatedModelClass,
+          field.name
+        );
+        fieldDefs.push(`${relationshipFieldName}: ${relDef}`);
+
+      } else {
+        // Regular attribute
+        const typeDef = this.typeMapper.mapAttributeType(
+          field.type,
+          field.optional,
+          field.isPartitionKey,
+          field.isSortKey,
+          field.enums
+        );
+        fieldDefs.push(`${field.name}: ${typeDef}`);
+      }
+    }
+
+    return fieldDefs.join(',\n    ');
+  }
+
+  secondaryIndexes(): string[] {
+    const metadata = this.extractMetadata();
+    const indexes: IndexMetadata[] = [];
+
+    for (const field of metadata.fields) {
+      if (field.isIndex && field.indexConfig) {
+        indexes.push({
+          fieldName: field.name,
+          indexName: field.indexConfig.name,
+          sortKeyField: field.indexConfig.sortKey,
+          type: field.indexConfig.type,
+          queryField: field.indexConfig.queryField
+        });
+      }
+    }
+
+    return this.indexGenerator.generateIndexes(indexes);
+  }
+
+  private extractMetadata(): EntityMetadata {
+    const keys: string[] = Reflect.getMetadata('keys', this.ModelClass.prototype) || [];
+    const joinTables: string[] = Reflect.getMetadata('joinTables', this.ModelClass.prototype) || [];
+
+    const fields: FieldMetadata[] = [];
+
+    // Process regular fields
+    for (const key of keys) {
+      const field = this.extractFieldMetadata(key);
+      fields.push(field);
+    }
+
+    // Process relationship fields (@HasOne/@HasMany)
+    for (const key of joinTables) {
+      if (keys.includes(key)) {
+        // Already processed
+        continue;
+      }
+
+      const field = this.extractRelationshipMetadata(key);
+      if (field) {
+        fields.push(field);
+      }
+    }
+
+    return {
+      tableName: this.getTableName(),
+      className: this.className,
+      fields
+    };
+  }
+
+  private extractFieldMetadata(key: string): FieldMetadata {
+    const prototype = this.ModelClass.prototype;
+
+    const type = Reflect.getMetadata('type', prototype, key);
+    const optional = Reflect.getMetadata('optional', prototype, key) || false;
+    const enums = Reflect.getMetadata('enums', prototype, key);
+
+    const partitionKey = Reflect.getMetadata('partitionKey', prototype, key);
+    const sortKey = Reflect.getMetadata('sortKey', prototype, key);
+    const amplifyGsi = Reflect.getMetadata('amplifyGsi', prototype, key);
+    const belongsTo = Reflect.getMetadata('belongsTo', prototype, key);
+
+    return {
+      name: key,
+      type,
+      optional,
+      isPartitionKey: !!partitionKey,
+      isSortKey: !!sortKey,
+      isIndex: !!amplifyGsi,
+      enums,
+      indexConfig: amplifyGsi ? {
+        type: amplifyGsi.type,
+        name: amplifyGsi.name,
+        sortKey: amplifyGsi.sortKey,
+        queryField: amplifyGsi.queryField
+      } : undefined,
+      relationship: belongsTo ? {
+        type: 'belongsTo',
+        relatedModelClass: this.inferRelatedModelFromFieldName(key)
+      } : undefined
+    };
+  }
+
+  private extractRelationshipMetadata(key: string): FieldMetadata | null {
+    const prototype = this.ModelClass.prototype;
+
+    const hasOne = Reflect.getMetadata('hasOne', prototype, key);
+    const hasMany = Reflect.getMetadata('hasMany', prototype, key);
+
+    if (hasOne) {
+      return {
+        name: key,
+        type: 'relationship',
+        optional: true,
+        isPartitionKey: false,
+        isSortKey: false,
+        isIndex: false,
+        relationship: {
+          type: 'hasOne',
+          relatedModelClass: hasOne()
+        }
+      };
+    }
+
+    if (hasMany) {
+      return {
+        name: key,
+        type: 'relationship',
+        optional: true,
+        isPartitionKey: false,
+        isSortKey: false,
+        isIndex: false,
+        relationship: {
+          type: 'hasMany',
+          relatedModelClass: hasMany()
+        }
+      };
+    }
+
+    return null;
+  }
+
+  private inferRelatedModelFromFieldName(fieldName: string): new () => any {
+    // For @BelongsTo fields like "userId", infer "User"
+    const modelName = fieldName.replace(/Id$/i, '');
+    const capitalizedName = modelName.charAt(0).toUpperCase() + modelName.slice(1);
+
+    // Create a mock class with the inferred name
+    // This is necessary because we need the name for code generation
+    const MockClass = class {};
+    Object.defineProperty(MockClass, 'name', { value: capitalizedName });
+    return MockClass as new () => any;
+  }
+
+  private getTableName(): string {
+    const tableNameProvider = Reflect.getMetadata('tableName', this.ModelClass);
+
+    if (typeof tableNameProvider === 'function') {
+      // Extract expression from arrow function
+      const fnString = tableNameProvider.toString();
+      const match = fnString.match(/(?:=>|return)\s*['"]?([^'";\s}]+)['"]?/);
+      return match ? match[1].trim() : tableNameProvider();
+    }
+
+    return tableNameProvider;
+  }
+}

--- a/src/adapters/amplify/AmplifyIndexGenerator.ts
+++ b/src/adapters/amplify/AmplifyIndexGenerator.ts
@@ -1,0 +1,45 @@
+import { IndexMetadata } from './types';
+
+export class AmplifyIndexGenerator {
+  constructor(private className: string) {}
+
+  generateIndexes(indexes: IndexMetadata[]): string[] {
+    return indexes.map(idx => this.generateSingleIndex(idx));
+  }
+
+  private generateSingleIndex(index: IndexMetadata): string {
+    // Use the queryField from metadata if provided, otherwise generate it
+    const queryField = index.queryField ?? this.generateQueryFieldName(index);
+
+    let indexDef: string;
+    if (index.sortKeyField) {
+      indexDef = `index('${index.indexName}').sortKeys(['${index.sortKeyField}']).name('${index.indexName}').queryField('${queryField}')`;
+    } else {
+      indexDef = `index('${index.indexName}').name('${index.indexName}').queryField('${queryField}')`;
+    }
+
+    return indexDef;
+  }
+
+  private generateQueryFieldName(index: IndexMetadata): string {
+    const pkPascal = this.toPascalCase(index.fieldName);
+
+    if (index.sortKeyField) {
+      const skPascal = this.toPascalCase(index.sortKeyField);
+      return `${this.className}By${pkPascal}-${skPascal}`;
+    }
+
+    return `${this.className}By${pkPascal}`;
+  }
+
+  private toPascalCase(str: string): string {
+    // Convert camelCase, snake_case, kebab-case to PascalCase
+    return str
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/[_-]/g, ' ')
+      .split(' ')
+      .filter(word => word.length > 0)
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join('');
+  }
+}

--- a/src/adapters/amplify/AmplifyRelationshipMapper.ts
+++ b/src/adapters/amplify/AmplifyRelationshipMapper.ts
@@ -1,0 +1,50 @@
+import 'reflect-metadata';
+
+export class AmplifyRelationshipMapper {
+  generateBelongsTo(relatedModelClass: new () => any, foreignKeyField: string): string {
+    const relatedModelName = relatedModelClass.name;
+    return `a.belongsTo('${relatedModelName}', '${foreignKeyField}')`;
+  }
+
+  generateHasOne(relatedModelClass: new () => any, currentModelClass: new () => any): string {
+    const relatedModelName = relatedModelClass.name;
+    const foreignKeyField = this.findForeignKeyInRelatedModel(relatedModelClass, currentModelClass);
+    return `a.hasOne('${relatedModelName}', '${foreignKeyField}')`;
+  }
+
+  generateHasMany(relatedModelClass: new () => any, currentModelClass: new () => any): string {
+    const relatedModelName = relatedModelClass.name;
+    const foreignKeyField = this.findForeignKeyInRelatedModel(relatedModelClass, currentModelClass);
+    return `a.hasMany('${relatedModelName}', '${foreignKeyField}')`;
+  }
+
+  private findForeignKeyInRelatedModel(
+    relatedModelClass: new () => any,
+    currentModelClass: new () => any
+  ): string {
+    // Get all keys from related model
+    const keys: string[] = Reflect.getMetadata('keys', relatedModelClass.prototype) || [];
+
+    // Find field with @BelongsTo decorator that references the current model
+    // Convention: look for field named like "<currentModelName>Id"
+    const currentModelName = currentModelClass.name;
+    const expectedFieldName = currentModelName.charAt(0).toLowerCase() + currentModelName.slice(1) + 'Id';
+
+    for (const key of keys) {
+      const belongsTo = Reflect.getMetadata('belongsTo', relatedModelClass.prototype, key);
+      if (belongsTo && key.toLowerCase() === expectedFieldName.toLowerCase()) {
+        return key;
+      }
+    }
+
+    // If convention doesn't work, find any @BelongsTo field
+    for (const key of keys) {
+      const belongsTo = Reflect.getMetadata('belongsTo', relatedModelClass.prototype, key);
+      if (belongsTo) {
+        return key;
+      }
+    }
+
+    throw new Error(`Cannot find @BelongsTo foreign key in ${relatedModelClass.name} referencing ${currentModelName}`);
+  }
+}

--- a/src/adapters/amplify/AmplifyTypeMapper.ts
+++ b/src/adapters/amplify/AmplifyTypeMapper.ts
@@ -1,0 +1,50 @@
+export class AmplifyTypeMapper {
+  mapAttributeType(
+    type: string,
+    optional: boolean,
+    isPartitionKey: boolean,
+    isSortKey: boolean,
+    enums?: string[]
+  ): string {
+    // Keys always use a.id().required()
+    if (isPartitionKey || isSortKey) {
+      return 'a.id().required()';
+    }
+
+    // Get base type
+    const baseType = this.getBaseType(type, enums);
+
+    // Apply required/optional modifier
+    return this.applyOptionalModifier(baseType, optional);
+  }
+
+  private getBaseType(type: string, enums?: string[]): string {
+    switch (type) {
+      case 'string':
+        return 'a.string()';
+      case 'number':
+        return 'a.float()';
+      case 'boolean':
+        return 'a.boolean()';
+      case 'date':
+        return 'a.datetime()';
+      case 'object':
+        return 'a.json()';
+      case 'array':
+        return 'a.json()';
+      case 'enums': {
+        if (!enums || enums.length === 0) {
+          throw new Error('Enum type requires enum values');
+        }
+        const enumValues = enums.map(e => `'${e}'`).join(', ');
+        return `a.enum([${enumValues}])`;
+      }
+      default:
+        throw new Error(`Unsupported type: ${type}`);
+    }
+  }
+
+  private applyOptionalModifier(baseType: string, optional: boolean): string {
+    return optional ? baseType : `${baseType}.required()`;
+  }
+}

--- a/src/adapters/amplify/README.md
+++ b/src/adapters/amplify/README.md
@@ -1,0 +1,760 @@
+# Amplify Gen 2 Adapter
+
+The Amplify Gen 2 Adapter translates decorator-based DynamoDB entity definitions into AWS Amplify Gen 2 schema material. This allows you to maintain a single source of truth for your data models and generate both DynamoDB schemas (via Repository) and Amplify Gen 2 schemas.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [CLI Usage](#cli-usage)
+- [API Reference](#api-reference)
+- [Decorators](#decorators)
+- [Type Mappings](#type-mappings)
+- [Examples](#examples)
+- [Best Practices](#best-practices)
+
+## Overview
+
+The adapter provides:
+
+1. **Material Generation**: Convert decorated entities to Amplify Gen 2 material (modelFields + secondaryIndexes)
+2. **CLI Tool**: Generate material files from entity directories
+3. **Type Safety**: Full TypeScript support with proper type mappings
+4. **Repository Compatibility**: Works seamlessly with the existing Repository class
+5. **Relationship Support**: Maps @BelongsTo, @HasOne, @HasMany to Amplify relationships
+
+## Installation
+
+```bash
+npm install @ivan-lee/typed-ddb
+# or
+pnpm add @ivan-lee/typed-ddb
+# or
+yarn add @ivan-lee/typed-ddb
+```
+
+The package includes all necessary dependencies including `tsx` for TypeScript support and `reflect-metadata` for decorator functionality.
+
+## Quick Start
+
+### 1. Define Your Entity
+
+```typescript
+import { Table, PartitionKey, Attribute } from '@ivan-lee/typed-ddb';
+import { AmplifyGsi } from '@ivan-lee/typed-ddb/adapters';
+
+@Table('Users')
+export class User {
+  @PartitionKey()
+  @Attribute({ type: 'string' })
+  id: string;
+
+  @AmplifyGsi({ queryField: 'usersByEmail' })
+  @Attribute({ type: 'string' })
+  email: string;
+
+  @Attribute({ type: 'string' })
+  name: string;
+
+  @Attribute({ type: 'number' })
+  age: number;
+
+  @Attribute({ type: 'date' })
+  CreatedAt: Date;
+
+  @Attribute({ type: 'date', optional: true })
+  UpdatedAt?: Date;
+}
+```
+
+### 2. Generate Material Files
+
+```bash
+npx typed-ddb amplify -i ./entities -o ./amplify/materials
+```
+
+This generates `User.material.ts`:
+
+```typescript
+export const UserMaterial = {
+  modelFields: {
+    id: a.id().required(),
+    email: a.string().required(),
+    name: a.string().required(),
+    age: a.float().required(),
+    CreatedAt: a.datetime().required(),
+    UpdatedAt: a.datetime()
+  },
+  secondaryIndexes: (index: any) => [
+    index.index('emailGlobalIndex').name('emailGlobalIndex').queryField('usersByEmail')
+  ]
+};
+```
+
+### 3. Use in Amplify Schema
+
+```typescript
+import { a } from '@aws-amplify/backend';
+import { UserMaterial } from './amplify/materials/User.material';
+
+export const User = a
+  .model(UserMaterial.modelFields)
+  .authorization((allow) => [
+    allow.authenticated()
+  ])
+  .secondaryIndexes(UserMaterial.secondaryIndexes);
+```
+
+## CLI Usage
+
+### Command Syntax
+
+```bash
+npx typed-ddb amplify -i <input-path> -o <output-path>
+```
+
+### Options
+
+- `-i, --input`: Path to directory containing entity class definitions (TypeScript files)
+- `-o, --output`: Path to output directory for generated material files
+
+### Example
+
+```bash
+# Generate materials from entities directory
+npx typed-ddb amplify -i src/entities -o amplify/data/materials
+
+# Using relative paths
+npx typed-ddb amplify -i ./models -o ./generated
+```
+
+### Features
+
+- Automatically loads TypeScript files without compilation
+- Scans for classes with @Table decorator
+- Generates one material file per entity
+- Creates output directory if it doesn't exist
+- Provides progress feedback during generation
+
+## API Reference
+
+### AmplifyAdapter
+
+Main class for generating Amplify Gen 2 material.
+
+```typescript
+class AmplifyAdapter<T> {
+  constructor(ModelClass: new () => T);
+  modelFields(): string;
+  secondaryIndexes(): string[];
+}
+```
+
+#### Methods
+
+**`modelFields(): string`**
+
+Generates the model fields definition as a formatted string.
+
+Returns:
+```typescript
+"id: a.id().required(),\n  email: a.string().required(),\n  ..."
+```
+
+**`secondaryIndexes(): string[]`**
+
+Generates secondary index definitions as an array of strings.
+
+Returns:
+```typescript
+[
+  "index('emailGlobalIndex').name('emailGlobalIndex').queryField('usersByEmail')",
+  "index('StatusIndex').sortKeys(['publishedAt']).name('StatusIndex').queryField('postsByStatus')"
+]
+```
+
+### Usage Example
+
+```typescript
+import { AmplifyAdapter } from '@ivan-lee/typed-ddb/adapters';
+import { User } from './entities/User';
+
+const adapter = new AmplifyAdapter(User);
+const fields = adapter.modelFields();
+const indexes = adapter.secondaryIndexes();
+
+console.log('Model Fields:', fields);
+console.log('Secondary Indexes:', indexes);
+```
+
+## Decorators
+
+### @AmplifyGsi
+
+Decorator for defining Amplify-compatible Global Secondary Indexes. This is a **superset** of the standard @Index decorator and works with both Amplify and the Repository class.
+
+```typescript
+@AmplifyGsi(options?: AmplifyGsiOptions)
+```
+
+#### Options
+
+```typescript
+interface AmplifyGsiOptions {
+  name?: string;          // Custom index name (auto-generated if not provided)
+  sortKey?: string;       // Sort key field name for composite indexes
+  queryField?: string;    // GraphQL query field name (REQUIRED)
+}
+```
+
+#### Examples
+
+**Simple GSI (partition key only):**
+
+```typescript
+@AmplifyGsi({ queryField: 'usersByEmail' })
+@Attribute({ type: 'string' })
+email: string;
+```
+
+Generates:
+```typescript
+index('emailGlobalIndex').name('emailGlobalIndex').queryField('usersByEmail')
+```
+
+**Composite GSI (partition key + sort key):**
+
+```typescript
+@AmplifyGsi({
+  name: 'StatusIndex',
+  sortKey: 'publishedAt',
+  queryField: 'postsByStatus'
+})
+@Attribute({ type: 'enums', enums: ['draft', 'published', 'archived'] })
+status: 'draft' | 'published' | 'archived';
+
+@Attribute({ type: 'number' })
+publishedAt: number;
+```
+
+Generates:
+```typescript
+index('StatusIndex').sortKeys(['publishedAt']).name('StatusIndex').queryField('postsByStatus')
+```
+
+#### Important Notes
+
+1. **Only decorate the partition key field** of the GSI, not the sort key
+2. **queryField is REQUIRED** - this is the GraphQL query name
+3. **Works with Repository** - No need to use both @Index and @AmplifyGsi
+4. **Always creates global indexes** - Local secondary indexes not supported
+
+## Type Mappings
+
+### Attribute Types to Amplify Types
+
+| Decorator Type | Amplify Type | Notes |
+|----------------|--------------|-------|
+| `string` | `a.string()` | Basic string type |
+| `number` | `a.float()` | Numeric values |
+| `boolean` | `a.boolean()` | True/false values |
+| `date` | `a.datetime()` | ISO datetime strings |
+| `object` | `a.json()` | JSON objects |
+| `array` | `a.json()` | JSON arrays |
+| `enums` | `a.enum([...])` | Enumerated values |
+
+### Key Types
+
+Partition keys and sort keys are always mapped to `a.id().required()` regardless of the original type.
+
+### Optional Fields
+
+Fields marked with `optional: true` omit the `.required()` modifier:
+
+```typescript
+// Optional field
+@Attribute({ type: 'string', optional: true })
+bio?: string;
+
+// Generates: a.string()
+```
+
+```typescript
+// Required field
+@Attribute({ type: 'string' })
+name: string;
+
+// Generates: a.string().required()
+```
+
+### Enum Types
+
+```typescript
+@Attribute({ type: 'enums', enums: ['draft', 'published', 'archived'] })
+status: 'draft' | 'published' | 'archived';
+
+// Generates: a.enum(['draft', 'published', 'archived']).required()
+```
+
+## Examples
+
+### Complete Entity with Relationships
+
+```typescript
+import { Table, PartitionKey, SortKey, Attribute, BelongsTo, HasMany } from '@ivan-lee/typed-ddb';
+import { AmplifyGsi } from '@ivan-lee/typed-ddb/adapters';
+
+@Table('Posts')
+export class Post {
+  @PartitionKey()
+  @Attribute({ type: 'string' })
+  id: string;
+
+  @Attribute({ type: 'string' })
+  title: string;
+
+  @Attribute({ type: 'string' })
+  content: string;
+
+  // Foreign key with BelongsTo relationship
+  @BelongsTo<Pick<User, 'id'>>(
+    (user: Pick<User, 'id'>) => user.id,
+    (userId: string) => ({ id: userId })
+  )
+  @Attribute({ type: 'string' })
+  userId: Pick<User, 'id'>;
+
+  // Composite GSI with sort key
+  @AmplifyGsi({
+    name: 'StatusIndex',
+    sortKey: 'publishedAt',
+    queryField: 'postsByStatus'
+  })
+  @Attribute({ type: 'enums', enums: ['draft', 'published', 'archived'] })
+  status: 'draft' | 'published' | 'archived';
+
+  @Attribute({ type: 'number' })
+  publishedAt: number;
+
+  @Attribute({ type: 'date' })
+  CreatedAt: Date;
+
+  @Attribute({ type: 'date', optional: true })
+  UpdatedAt?: Date;
+
+  // HasMany relationship
+  @HasMany(() => Comment)
+  comments?: Comment[];
+}
+```
+
+Generated material:
+
+```typescript
+export const PostMaterial = {
+  modelFields: {
+    id: a.id().required(),
+    title: a.string().required(),
+    content: a.string().required(),
+    userId: a.id().required(),
+    user: a.belongsTo('User', 'userId'),
+    status: a.enum(['draft', 'published', 'archived']).required(),
+    publishedAt: a.float().required(),
+    CreatedAt: a.datetime().required(),
+    UpdatedAt: a.datetime(),
+    comments: a.hasMany('Comment', 'postId')
+  },
+  secondaryIndexes: (index: any) => [
+    index.index('StatusIndex').sortKeys(['publishedAt']).name('StatusIndex').queryField('postsByStatus')
+  ]
+};
+```
+
+### Entity Without Indexes
+
+```typescript
+@Table('Profiles')
+export class Profile {
+  @PartitionKey()
+  @BelongsTo<Pick<User, 'id'>>(
+    (user: Pick<User, 'id'>) => user.id,
+    (userId: string) => ({ id: userId })
+  )
+  @Attribute({ type: 'string' })
+  userId: Pick<User, 'id'>;
+
+  @Attribute({ type: 'string', optional: true })
+  bio?: string;
+
+  @Attribute({ type: 'object', optional: true })
+  settings?: Record<string, any>;
+
+  @Attribute({ type: 'date' })
+  CreatedAt: Date;
+}
+```
+
+Generated material:
+
+```typescript
+export const ProfileMaterial = {
+  modelFields: {
+    userId: a.id().required(),
+    user: a.belongsTo('User', 'userId'),
+    bio: a.string(),
+    settings: a.json(),
+    CreatedAt: a.datetime().required()
+  },
+  secondaryIndexes: () => []
+};
+```
+
+### Multiple Entities Project Structure
+
+```
+project/
+├── src/
+│   ├── entities/
+│   │   ├── User.ts
+│   │   ├── Post.ts
+│   │   ├── Comment.ts
+│   │   └── Profile.ts
+│   └── ...
+└── amplify/
+    ├── data/
+    │   ├── materials/          # Generated by CLI
+    │   │   ├── User.material.ts
+    │   │   ├── Post.material.ts
+    │   │   ├── Comment.material.ts
+    │   │   └── Profile.material.ts
+    │   └── resource.ts         # Your Amplify schema
+    └── ...
+```
+
+Generate materials:
+```bash
+npx typed-ddb amplify -i src/entities -o amplify/data/materials
+```
+
+Compose in `amplify/data/resource.ts`:
+```typescript
+import { a, defineData } from '@aws-amplify/backend';
+import { UserMaterial } from './materials/User.material';
+import { PostMaterial } from './materials/Post.material';
+import { CommentMaterial } from './materials/Comment.material';
+import { ProfileMaterial } from './materials/Profile.material';
+
+const schema = a.schema({
+  User: a
+    .model(UserMaterial.modelFields)
+    .authorization((allow) => [allow.authenticated()])
+    .secondaryIndexes(UserMaterial.secondaryIndexes),
+
+  Post: a
+    .model(PostMaterial.modelFields)
+    .authorization((allow) => [
+      allow.authenticated().to(['read']),
+      allow.owner()
+    ])
+    .secondaryIndexes(PostMaterial.secondaryIndexes),
+
+  Comment: a
+    .model(CommentMaterial.modelFields)
+    .authorization((allow) => [allow.authenticated()])
+    .secondaryIndexes(CommentMaterial.secondaryIndexes),
+
+  Profile: a
+    .model(ProfileMaterial.modelFields)
+    .authorization((allow) => [allow.owner()])
+    .secondaryIndexes(ProfileMaterial.secondaryIndexes),
+});
+
+export type Schema = ClientSchema<typeof schema>;
+export const data = defineData({ schema });
+```
+
+## Best Practices
+
+### 1. Use @AmplifyGsi Instead of @Index
+
+When building for Amplify, use `@AmplifyGsi` which provides better integration:
+
+```typescript
+// Good: Use @AmplifyGsi
+@AmplifyGsi({ queryField: 'usersByEmail' })
+@Attribute({ type: 'string' })
+email: string;
+
+// Avoid: Using @Index for Amplify projects
+@Index({ name: 'emailIndex', type: 'global' })
+@Attribute({ type: 'string' })
+email: string;
+```
+
+### 2. Always Provide queryField
+
+The `queryField` option is required and determines the GraphQL query name:
+
+```typescript
+// Good: Explicit queryField
+@AmplifyGsi({ queryField: 'postsByAuthor' })
+@Attribute({ type: 'string' })
+authorId: string;
+```
+
+### 3. Decorator Order Matters
+
+Always place key decorators before `@Attribute`:
+
+```typescript
+// Correct order
+@PartitionKey()
+@AmplifyGsi({ queryField: 'usersByEmail' })
+@Attribute({ type: 'string' })
+email: string;
+
+// Wrong order (will fail)
+@Attribute({ type: 'string' })
+@PartitionKey()  // ❌ Too late
+email: string;
+```
+
+### 4. Only Decorate GSI Partition Keys
+
+Don't apply `@AmplifyGsi` to both partition and sort keys:
+
+```typescript
+// Correct: Only decorate the partition key
+@AmplifyGsi({
+  name: 'StatusIndex',
+  sortKey: 'publishedAt',
+  queryField: 'postsByStatus'
+})
+@Attribute({ type: 'string' })
+status: string;
+
+// The sort key field should NOT have @AmplifyGsi
+@Attribute({ type: 'number' })
+publishedAt: number;
+```
+
+### 5. Separate Concerns
+
+Keep your authorization rules in Amplify schema, not in entity definitions:
+
+```typescript
+// Entity definition (no auth)
+@Table('Users')
+export class User {
+  // ... fields
+}
+
+// Amplify schema (with auth)
+export const User = a
+  .model(UserMaterial.modelFields)
+  .authorization((allow) => [
+    allow.authenticated(),
+    allow.owner()
+  ])
+  .secondaryIndexes(UserMaterial.secondaryIndexes);
+```
+
+### 6. Auto-Managed Timestamps
+
+The library auto-manages `CreatedAt` and `UpdatedAt`:
+
+```typescript
+@Attribute({ type: 'date' })
+CreatedAt: Date;  // Set automatically on create
+
+@Attribute({ type: 'date', optional: true })
+UpdatedAt?: Date;  // Set automatically on update
+```
+
+Don't manually set these values in your application code.
+
+### 7. Regenerate After Schema Changes
+
+Always regenerate material files after changing entity definitions:
+
+```bash
+# After modifying entities
+npx typed-ddb amplify -i src/entities -o amplify/data/materials
+
+# Then rebuild your Amplify backend
+npx ampx sandbox
+```
+
+### 8. Version Control
+
+**Do commit:** Generated material files (`.material.ts`)
+**Don't commit:** Compiled JavaScript files from dist/
+
+```gitignore
+# .gitignore
+/dist
+/node_modules
+
+# DO commit these:
+# /amplify/data/materials/*.material.ts
+```
+
+### 9. TypeScript Configuration
+
+Ensure your `tsconfig.json` includes decorator support:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+### 10. Testing Both Layers
+
+Test your entities work with both Repository and Amplify:
+
+```typescript
+// Test with Repository
+import { Repository } from '@ivan-lee/typed-ddb';
+const repo = new Repository(User);
+await repo.create({ email: 'test@example.com', ... });
+
+// Test material generation
+import { AmplifyAdapter } from '@ivan-lee/typed-ddb/adapters';
+const adapter = new AmplifyAdapter(User);
+const fields = adapter.modelFields();
+const indexes = adapter.secondaryIndexes();
+```
+
+## Architecture
+
+### Component Overview
+
+```
+AmplifyAdapter (Main orchestrator)
+├── AmplifyTypeMapper (Type conversions)
+├── AmplifyIndexGenerator (Index definitions)
+└── AmplifyRelationshipMapper (Relationship mapping)
+```
+
+### Type Mapper
+
+Converts decorator types to Amplify types:
+- Handles primitive types (string, number, boolean, date)
+- Converts objects and arrays to JSON
+- Maps enums with value lists
+- Applies optional/required modifiers
+
+### Index Generator
+
+Creates secondary index definitions:
+- Generates deterministic index names
+- Handles composite indexes with sort keys
+- Creates queryField names for GraphQL
+- Formats as Amplify .secondaryIndexes() calls
+
+### Relationship Mapper
+
+Maps decorator relationships to Amplify:
+- @BelongsTo → a.belongsTo()
+- @HasOne → a.hasOne()
+- @HasMany → a.hasMany()
+- Infers foreign key fields automatically
+
+## Troubleshooting
+
+### CLI Not Loading TypeScript Files
+
+**Problem:** `Invalid or unexpected token` when loading .ts files
+
+**Solution:** Ensure `tsx` is installed as a dependency (not devDependency):
+```bash
+npm install tsx
+```
+
+### reflect-metadata Errors
+
+**Problem:** `Reflect.getMetadata is not a function`
+
+**Solution:** Import reflect-metadata at the top of your entry file:
+```typescript
+import 'reflect-metadata';
+```
+
+### Missing Index Metadata
+
+**Problem:** Indexes not showing in generated material
+
+**Solution:** Ensure you're using `@AmplifyGsi` and it's placed before `@Attribute`:
+```typescript
+@AmplifyGsi({ queryField: 'usersByEmail' })
+@Attribute({ type: 'string' })
+email: string;
+```
+
+### Wrong Amplify Type Generated
+
+**Problem:** Field generates wrong Amplify type (e.g., a.string() instead of a.id())
+
+**Solution:** Check if field is marked as partition/sort key:
+```typescript
+@PartitionKey()  // This makes it generate a.id().required()
+@Attribute({ type: 'string' })
+id: string;
+```
+
+### Repository Not Working with @AmplifyGsi
+
+**Problem:** Repository can't find indexes created with @AmplifyGsi
+
+**Solution:** @AmplifyGsi should work automatically. Verify metadata is stored:
+```typescript
+const metadata = Reflect.getMetadata('index', User.prototype, 'email');
+console.log(metadata); // Should show index metadata
+```
+
+## Migration Guide
+
+### From @Index to @AmplifyGsi
+
+If you're currently using `@Index` for Amplify projects:
+
+**Before:**
+```typescript
+@Index({ name: 'emailIndex', type: 'global' })
+@Attribute({ type: 'string' })
+email: string;
+```
+
+**After:**
+```typescript
+@AmplifyGsi({
+  name: 'emailIndex',
+  queryField: 'usersByEmail'  // Add this
+})
+@Attribute({ type: 'string' })
+email: string;
+```
+
+Benefits:
+- Explicit queryField for GraphQL
+- Works with Repository without changes
+- Better Amplify Gen 2 integration
+
+## Contributing
+
+Found a bug or want to contribute? Please see the main project repository.
+
+## License
+
+MIT
+
+## Support
+
+For issues and questions:
+- GitHub Issues: https://github.com/ivan-zynesis/typed-ddb/issues
+- Documentation: See main README.md in project root

--- a/src/adapters/amplify/decorators.ts
+++ b/src/adapters/amplify/decorators.ts
@@ -1,0 +1,92 @@
+import 'reflect-metadata';
+
+// Import the utility function for index naming
+function constructGSIname(type: 'global' | 'local', hashKey: string, sortKey?: string) {
+  return `${hashKey}${sortKey ? '-' : ''}${sortKey ?? ''}${type === 'global' ? 'GlobalIndex' : 'LocalIndex'}`;
+}
+
+export interface AmplifyGsiOptions {
+  /**
+   * Name of the global secondary index
+   * If not provided, will follow naming convention: `${fieldName}GlobalIndex`
+   */
+  name?: string;
+
+  /**
+   * Sort key field name for composite index
+   * @example 'publishedAt'
+   */
+  sortKey?: string;
+
+  /**
+   * GraphQL query field name for this index
+   * REQUIRED for Amplify Gen 2
+   * @example 'postsByStatus', 'usersByEmail'
+   */
+  queryField: string;
+}
+
+/**
+ * Decorator for defining Amplify Gen 2 compatible Global Secondary Indexes
+ *
+ * This decorator is a superset of the standard @Index decorator that:
+ * - Always creates GLOBAL indexes (not local)
+ * - Works with Repository for DynamoDB operations
+ * - Stores queryField metadata for Amplify Gen 2 schema generation
+ * - Supports optional index naming and sort key specification
+ *
+ * ⚠️ IMPORTANT: This decorator creates BOTH:
+ * 1. Actual DynamoDB index metadata for Repository operations
+ * 2. Amplify-specific metadata for schema generation
+ *
+ * You should NOT use both @Index and @AmplifyGsi on the same field.
+ *
+ * @example
+ * // Simple index (partition key only)
+ * @AmplifyGsi({ queryField: 'usersByEmail' })
+ * @Attribute({ type: 'string' })
+ * email: string;
+ *
+ * @example
+ * // Composite index (partition key + sort key)
+ * @AmplifyGsi({
+ *   name: 'StatusIndex',
+ *   sortKey: 'publishedAt',
+ *   queryField: 'postsByStatus'
+ * })
+ * @Attribute({ type: 'enums', enums: ['draft', 'published'] })
+ * status: 'draft' | 'published';
+ */
+export function AmplifyGsi(options: AmplifyGsiOptions) {
+  return (target: any, propertyKey: string) => {
+    const type = 'global'; // Always global
+    const indexName = options.name ?? constructGSIname(type, propertyKey, options.sortKey);
+
+    // Store standard @Index metadata for Repository operations
+    const propertyType = Reflect.getMetadata('type', target, propertyKey);
+    Reflect.defineMetadata('index', {
+      type,
+      name: options.name,
+      sortKey: options.sortKey,
+    }, target, propertyKey);
+
+    Reflect.defineMetadata(`partitionKey(${indexName})`, { field: propertyKey, type: propertyType }, target, propertyKey);
+
+    if (options.sortKey) {
+      const sortKeyPropertyType = Reflect.getMetadata('type', target, options.sortKey);
+      Reflect.defineMetadata(`sortKey(${indexName})`, { field: options.sortKey, type: sortKeyPropertyType }, target, options.sortKey);
+    }
+
+    // Store Amplify-specific metadata
+    Reflect.defineMetadata('amplifyGsi', {
+      name: indexName,
+      sortKey: options.sortKey,
+      queryField: options.queryField,
+      type
+    }, target, propertyKey);
+
+    // Track all decorated keys with AmplifyGsi
+    const keys = Reflect.getMetadata('amplifyGsiKeys', target) || [];
+    Reflect.defineMetadata('amplifyGsiKeys', [...keys, propertyKey], target);
+  };
+}

--- a/src/adapters/amplify/types.ts
+++ b/src/adapters/amplify/types.ts
@@ -1,0 +1,33 @@
+export interface FieldMetadata {
+  name: string;
+  type: string;
+  optional: boolean;
+  isPartitionKey: boolean;
+  isSortKey: boolean;
+  isIndex: boolean;
+  enums?: string[];
+  indexConfig?: {
+    type: 'global' | 'local';
+    name: string;
+    sortKey?: string;
+    queryField?: string;
+  };
+  relationship?: {
+    type: 'belongsTo' | 'hasOne' | 'hasMany';
+    relatedModelClass?: new () => any;
+  };
+}
+
+export interface EntityMetadata {
+  tableName: string;
+  className: string;
+  fields: FieldMetadata[];
+}
+
+export interface IndexMetadata {
+  fieldName: string;
+  indexName: string;
+  sortKeyField?: string;
+  type: 'global' | 'local';
+  queryField?: string;
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,8 @@
+export { AmplifyAdapter } from './amplify/AmplifyAdapter';
+export { AmplifyGsi } from './amplify/decorators';
+export type { AmplifyGsiOptions } from './amplify/decorators';
+export type {
+  EntityMetadata,
+  FieldMetadata,
+  IndexMetadata
+} from './amplify/types';

--- a/src/cli/amplify.ts
+++ b/src/cli/amplify.ts
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { AmplifyAdapter } from '../adapters/amplify/AmplifyAdapter';
+
+// Enable TypeScript loading for Node.js
+import 'reflect-metadata';
+
+interface CliOptions {
+  input: string;
+  output: string;
+}
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  let input = '';
+  let output = '';
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '-i' || args[i] === '--input') {
+      input = args[i + 1];
+      i++;
+    } else if (args[i] === '-o' || args[i] === '--output') {
+      output = args[i + 1];
+      i++;
+    }
+  }
+
+  if (!input || !output) {
+    console.error('Usage: typed-ddb amplify -i <input-path> -o <output-path>');
+    console.error('  -i, --input   Path to directory containing entity class definitions');
+    console.error('  -o, --output  Path to output directory for generated material files');
+    process.exit(1);
+  }
+
+  return { input, output };
+}
+
+async function loadEntitiesFromDirectory(dirPath: string): Promise<Map<string, new () => any>> {
+  const entities = new Map<string, new () => any>();
+  const absolutePath = path.resolve(process.cwd(), dirPath);
+
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Input directory does not exist: ${absolutePath}`);
+  }
+
+  // Register tsx/ts-node for TypeScript support
+  try {
+    require('tsx/cjs/api').register();
+  } catch {
+    try {
+      require('ts-node/register/transpile-only');
+    } catch {
+      // Neither tsx nor ts-node available, will only support .js files
+    }
+  }
+
+  const files = fs.readdirSync(absolutePath).filter(f =>
+    (f.endsWith('.ts') || f.endsWith('.js')) && !f.endsWith('.d.ts')
+  );
+
+  for (const file of files) {
+    const filePath = path.join(absolutePath, file);
+    try {
+      // Use require for synchronous loading (works with tsx/ts-node registered)
+      const module = require(filePath);
+
+      // Find exported classes
+      for (const [exportName, exportValue] of Object.entries(module)) {
+        if (typeof exportValue === 'function' && exportValue.prototype) {
+          // Check if it has @Table decorator metadata
+          const tableName = Reflect.getMetadata('tableName', exportValue);
+          if (tableName) {
+            entities.set(exportName, exportValue as new () => any);
+          }
+        }
+      }
+    } catch (error) {
+      console.warn(`Warning: Could not load ${file}:`, error instanceof Error ? error.message : error);
+    }
+  }
+
+  return entities;
+}
+
+function generateMaterialFile(entityName: string, EntityClass: new () => any): string {
+  const adapter = new AmplifyAdapter(EntityClass);
+  const modelFields = adapter.modelFields();
+  const secondaryIndexes = adapter.secondaryIndexes();
+
+  // Convert modelFields string to object format
+  const fieldsArray = modelFields.split(',\n    ').map(field => field.trim());
+  const fieldsObject: Record<string, string> = {};
+
+  for (const field of fieldsArray) {
+    const [name, ...typeParts] = field.split(':');
+    const type = typeParts.join(':').trim();
+    fieldsObject[name.trim()] = type;
+  }
+
+  return `/**
+ * Auto-generated Amplify Gen 2 material for ${entityName}
+ * Generated from entity class definitions
+ *
+ * Usage:
+ * import { ${entityName}Material } from './path/to/this/file';
+ * import { a } from '@aws-amplify/backend';
+ *
+ * export const ${entityName} = a
+ *   .model(${entityName}Material.modelFields)
+ *   .authorization((allow) => [
+ *     // Your auth rules here
+ *   ])
+ *   .secondaryIndexes((index) => ${entityName}Material.secondaryIndexes);
+ */
+
+export const ${entityName}Material = {
+  modelFields: ${JSON.stringify(fieldsObject, null, 2)
+    .replace(/"([^"]+)":/g, '$1:')
+    .replace(/"/g, '')},
+  secondaryIndexes: ${secondaryIndexes.length > 0
+    ? `(index: any) => [\n    ${secondaryIndexes.map(idx => `index.${idx}`).join(',\n    ')}\n  ]`
+    : '() => []'}
+};
+`;
+}
+
+async function main() {
+  const options = parseArgs();
+
+  console.log('Loading entities from:', options.input);
+  const entities = await loadEntitiesFromDirectory(options.input);
+
+  if (entities.size === 0) {
+    console.error('No entities with @Table decorator found in:', options.input);
+    process.exit(1);
+  }
+
+  console.log(`Found ${entities.size} entities:`, Array.from(entities.keys()).join(', '));
+
+  // Create output directory if it doesn't exist
+  const outputPath = path.resolve(process.cwd(), options.output);
+  if (!fs.existsSync(outputPath)) {
+    fs.mkdirSync(outputPath, { recursive: true });
+  }
+
+  // Generate material files for each entity
+  for (const [entityName, EntityClass] of entities) {
+    const materialCode = generateMaterialFile(entityName, EntityClass);
+    const outputFile = path.join(outputPath, `${entityName}.material.ts`);
+
+    fs.writeFileSync(outputFile, materialCode, 'utf-8');
+    console.log(`✓ Generated: ${outputFile}`);
+  }
+
+  console.log(`\nSuccessfully generated ${entities.size} material files in ${outputPath}`);
+}
+
+main().catch(error => {
+  console.error('Error:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const command = process.argv[2];
+
+if (!command) {
+  console.error('Usage: typed-ddb <command> [options]');
+  console.error('');
+  console.error('Commands:');
+  console.error('  amplify    Generate Amplify Gen 2 material from entity definitions');
+  console.error('');
+  console.error('Run "typed-ddb <command> --help" for more information on a command.');
+  process.exit(1);
+}
+
+if (command === 'amplify') {
+  require('./amplify');
+} else {
+  console.error(`Unknown command: ${command}`);
+  console.error('Run "typed-ddb --help" for usage information.');
+  process.exit(1);
+}

--- a/src/dynamodb/core/decorators.ts
+++ b/src/dynamodb/core/decorators.ts
@@ -98,6 +98,11 @@ export function Attribute(options: AttributeOptions) {
     Reflect.defineMetadata('isArray', options.type === 'array', target, propertyKey);
     Reflect.defineMetadata('isDate', options.type === 'date', target, propertyKey);
 
+    // Store enum values for AmplifyAdapter
+    if (options.type === 'enums') {
+      Reflect.defineMetadata('enums', options.enums, target, propertyKey);
+    }
+
     // Track all decorated keys
     const keys = Reflect.getMetadata('keys', target) || [];
     Reflect.defineMetadata('keys', [...keys, propertyKey], target);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './dynamodb';
+export * from './adapters';


### PR DESCRIPTION
# Background

AWS Amplify gen 2 is using imperative schema definition which would can create a strongly typed GraphQL client for frontend use. However, there is no available ORM library that is able to leverage the Amplify schema without manually redefining all the interfaces. The lack of backend-use ORM layer inspired creation of this adapter that allows our TypeORM like schema to programmatically produce Amplify schema. A single source of truth of schema definition would be used for both frontend graphql client and backend ORM layer.