### PR TITLE
[Feature]: Expose lazy create config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ivan-lee/typed-ddb",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "A package to hold all helper libraries related for data modeling and transformation",
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json --force",

--- a/src/dynamodb/core/Repository.ts
+++ b/src/dynamodb/core/Repository.ts
@@ -32,7 +32,7 @@ export class Repository<T, PaginationKey extends string = string> {
   protected readonly model;
   readonly ModelClass: new () => T;
 
-  constructor(ModelClass: new () => T) {
+  constructor(ModelClass: new () => T, lazyCreate = true) {
     this.ModelClass = ModelClass;
     // Generate DynamoDB schema dynamically
     const schemaFields: any = {};
@@ -74,7 +74,7 @@ export class Repository<T, PaginationKey extends string = string> {
     const schema = new Schema(schemaFields);
 
     // Initialize the Dynamoose model
-    this.model = model(tableName, schema);
+    this.model = model(tableName, schema, { create: lazyCreate });
   }
 
   // Helper to get the @PartitionKey metadata


### PR DESCRIPTION
Allow construct Repository with lazy create flag disabled. Main purpose is to avoid non administrative client requires create table permission.